### PR TITLE
WIP: Remove slug from toc array

### DIFF
--- a/libraries/lambda_handlers/uw_v2_catalog_handler.py
+++ b/libraries/lambda_handlers/uw_v2_catalog_handler.py
@@ -317,7 +317,6 @@ class UwV2CatalogHandler(InstanceHandler):
                             'desc': '',
                             'media': media,
                             'mod': mod,
-                            'slug': proj['identifier'],
                             'src': source['url'],
                             'src_sig': source['signature'],
                             'title': proj['title'],


### PR DESCRIPTION
the slug in the toc array is causing a crash in the uW app as it is seeing 2 entries for the language